### PR TITLE
Fix HexDecimal definintion

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ SMT-LIB language ([SMT-LIB Standard: Version
 # Credits to Contributors
 I am very thankful for contributions in any shape or form (bugfixes, improvements, suggestions, comments). Many thanks to all contributors below for their valuabel help.
 - [Jake Vossen](https://github.com/jakevossen5), Bugfix: [binary digits should be prefixed by #b](https://github.com/julianthome/smtlibv2-grammar/pull/5)
+- [roundEaredSengi](https://github.com/roundEaredSengi), Bugfix: [Fix HexDecimal definintion](https://github.com/julianthome/smtlibv2-grammar/pull/7)
 
 # Status
 

--- a/src/main/resources/SMTLIBv2.g4
+++ b/src/main/resources/SMTLIBv2.g4
@@ -261,7 +261,7 @@ Binary
     ;
 
 HexDecimal
-    : '#x' HexDigit HexDigit HexDigit HexDigit
+    : '#x' HexDigit+
     ;
 
 Decimal


### PR DESCRIPTION
Fixing the HexDecimal definition as it deviates from the smt-lib spec